### PR TITLE
Fix test synchrononization

### DIFF
--- a/test/support/http_case.ex
+++ b/test/support/http_case.ex
@@ -23,10 +23,18 @@ defmodule HTTPStream.HTTPCase do
       respond_with: response_module
     )
 
-    {:ok, _pid} = HTTPServer.start()
+    {:ok, pid} = HTTPServer.start()
 
     on_exit(fn ->
+      ref = Process.monitor(pid)
+
       HTTPServer.stop()
+
+      receive do
+        {:DOWN, ^ref, _, _, _} ->
+          :ok
+      end
+
       Application.put_env(:http_stream, HTTPServer, config)
     end)
 


### PR DESCRIPTION
Why:

* `on_exit` callbacks run in a separate process, which means that
between tests the server might actually still be running.
* This is leading to stochastic builds on CI.

This change addresses the need by:

* Monitoring the server and waiting for it to terminate before exiting
the callback